### PR TITLE
Added special syncing to allow Imitator to see allies

### DIFF
--- a/lua/terrortown/entities/roles/imitator/shared.lua
+++ b/lua/terrortown/entities/roles/imitator/shared.lua
@@ -199,10 +199,10 @@ if SERVER then
 		if not ply.imit_has_voted then return end
 
 		for tra in pairs(tbl) do
-			if tra:IsTerror() and (tra:GetTeam() == TEAM_TRAITOR or tra:GetSubRoleData().defaultTeam == TEAM_TRAITOR or tra:GetSubRole() == ROLE_SPY) and tra ~= ply then
+			if tra:IsTerror() and (tra:GetTeam() == ply:GetTeam() or tra:GetSubRoleData().defaultTeam == ply:GetTeam() or tra:GetSubRole() == ROLE_SPY) and tra ~= ply then
 				tbl[tra] = {ROLE_TRAITOR, TEAM_TRAITOR}
 			elseif ply == tra then
-				tbl[tra] = {tbl[tra][1], TEAM_TRAITOR}
+				tbl[tra] = {tbl[tra][1], tra:GetTeam()}
 			end
 		end
 	end)

--- a/lua/terrortown/entities/roles/imitator/shared.lua
+++ b/lua/terrortown/entities/roles/imitator/shared.lua
@@ -193,6 +193,19 @@ if SERVER then
 			return false
 		end
 	end)
+
+	--Allow Imitator to see traitor allies
+	hook.Add("TTT2SpecialRoleSyncing", "TTT2ImitatorSeeTraitorTeam", function(ply, tbl)
+		if not ply.imit_has_voted then return end
+
+		for tra in pairs(tbl) do
+			if tra:IsTerror() and (tra:GetTeam() == TEAM_TRAITOR or tra:GetSubRoleData().defaultTeam == TEAM_TRAITOR or tra:GetSubRole() == ROLE_SPY) and tra ~= ply then
+				tbl[tra] = {ROLE_TRAITOR, TEAM_TRAITOR}
+			elseif ply == tra then
+				tbl[tra] = {tbl[tra][1], TEAM_TRAITOR}
+			end
+		end
+	end)
 end
 
 if CLIENT then


### PR DESCRIPTION
Presently, the Imitator can't see their teammates (or sometimes their correct team) after imitating. I've added role syncing which shows the traitors (and the Spy) to the imitator and enforces them seeing their team as Traitor.